### PR TITLE
Fix crash on completion due to incorrect str/list concatenation

### DIFF
--- a/tern.py
+++ b/tern.py
@@ -169,8 +169,8 @@ def start_server(project):
   if platform.system() == "Darwin":
     env = os.environ.copy()
     env["PATH"] += ":/usr/local/bin"
-  proc = subprocess.Popen(tern_command + tern_arguments, cwd=project.dir, env=env,
-                          stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+  proc = subprocess.Popen(tern_command + " ".join(tern_arguments), cwd=project.dir,
+                          env=env, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                           stderr=subprocess.STDOUT, shell=windows)
   output = ""
 


### PR DESCRIPTION
Triggering completion used to cause a

```python
Traceback (most recent call last):
  File "/opt/sublime_text/sublime_plugin.py", line 591, in on_query_completions
    res = callback.on_query_completions(v, prefix, locations)
  File "/home/ronj/.config/sublime-text-3/Packages/tern_for_sublime/tern.py", line 63, in on_query_completions
    completions, fresh = ensure_completions_cached(pfile, view)
  File "/home/ronj/.config/sublime-text-3/Packages/tern_for_sublime/tern.py", line 415, in ensure_completions_cached
    data = run_command(view, {"type": "completions", "types": True, "includeKeywords": True})
  File "/home/ronj/.config/sublime-text-3/Packages/tern_for_sublime/tern.py", line 294, in run_command
    port, port_is_old = server_port(pfile.project)
  File "/home/ronj/.config/sublime-text-3/Packages/tern_for_sublime/tern.py", line 160, in server_port
    started = start_server(project)
  File "/home/ronj/.config/sublime-text-3/Packages/tern_for_sublime/tern.py", line 173, in start_server
    proc = subprocess.Popen(tern_command + tern_arguments, cwd=project.dir, env=env,
TypeError: Can't convert 'list' object to str implicitly
```